### PR TITLE
Parsequery

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var defaultOptions = {
 };
 
 module.exports = function(source) {
-    var userOptions = loaderUtils.parseQuery(this.query);
+    var userOptions = loaderUtils.getOptions(this);
     var instrumenter = new istanbul.Instrumenter(
         assign({}, defaultOptions, userOptions)
     );

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "files": [ "index.js" ],
   "dependencies": {
     "istanbul": "0.x.x",
-    "loader-utils": "0.x.x",
+    "loader-utils": "1.x.x",
     "object-assign": "4.x.x"
   },
   "engines": {


### PR DESCRIPTION
There is following warning if options as object exists
```
const instanbulInstrumenterCfg = {
  test: /\.js$/,
  exclude: /(tests|node_modules|bower_components)\//,
  loader: 'istanbul-instrumenter',
  options: {
    esModules: true
  }
}
```
> DeprecationWarning: loaderUtils.parseQuery() received a non-string value which can be problematic, see https://github.com/webpack/loader-utils/issues/56
> parseQuery() will be replaced with getOptions() in the next major version of loader-utils.

